### PR TITLE
设备认证兼容EMQX 5

### DIFF
--- a/shared/result/httpResult.go
+++ b/shared/result/httpResult.go
@@ -9,12 +9,26 @@ import (
 	"github.com/zeromicro/go-zero/rest/httpx"
 )
 
-//http返回
+// Http http返回
 func Http(w http.ResponseWriter, r *http.Request, resp any, err error) {
 	if err == nil {
 		//成功返回
 		r := Success(resp)
 		httpx.WriteJson(w, http.StatusOK, r)
+	} else {
+		//错误返回
+		er := errors.Fmt(err)
+		logx.WithContext(r.Context()).Errorf("【http handle err】router:%v err: %v ",
+			r.URL.Path, utils.Fmt(er))
+		httpx.WriteJson(w, http.StatusBadRequest, Error(er.Code, er.Msg))
+	}
+}
+
+// HttpWithoutWrap http返回，无包装
+func HttpWithoutWrap(w http.ResponseWriter, r *http.Request, resp any, err error) {
+	if err == nil {
+		//成功返回
+		httpx.WriteJson(w, http.StatusOK, resp)
 	} else {
 		//错误返回
 		er := errors.Fmt(err)

--- a/src/apisvr/http/things/device.api
+++ b/src/apisvr/http/things/device.api
@@ -6,6 +6,7 @@ info(
 	version: "v1"
 )
 import "things/device/auth.api" //设备校验接口
+import "things/device/auth5.api" //设备校验接口
 import "things/device/msg.api" //设备消息获取接口
 import "things/device/gateway.api"  //设备网关子设备模块相关接口
 import "things/device/info.api"  //设备管理模块相关接口

--- a/src/apisvr/http/things/device/auth5.api
+++ b/src/apisvr/http/things/device/auth5.api
@@ -1,0 +1,42 @@
+info(
+    title: "认证管理(p2)"
+    desc: "认证管理(p2)"
+    author: "杨磊"
+    email: "603685348@qq.com"
+    version: "v1"
+)
+
+@server(
+    group : things/device/auth5
+    prefix: /api/v1/things/device/auth5
+)
+service api {
+    @doc "设备登录认证"
+    @handler login
+    post /login (DeviceAuth5LoginReq) returns (DeviceAuth5LoginResp)
+    @doc "设备操作认证"
+    @handler access
+    post /access (DeviceAuth5AccessReq) returns (DeviceAuth5AccessResp)
+}
+
+type DeviceAuth5LoginReq {
+    Username    string `json:"username"`                       //用户名
+    Password    string `json:"password,optional"`              //密码
+    ClientID    string `json:"clientID"`                       //clientID
+    Ip          string `json:"ip"`                             //访问的ip地址
+    Certificate string `json:"certificate,optional,omitempty"` //客户端证书 base64后传过来
+}
+type DeviceAuth5LoginResp {
+    Result      string `json:"result"`              //验证结果 "allow" | "deny" | "ignore"
+    IsSuperuser bool `json:"is_superuser,optional"` //是否为超级用户，可选 true | false，该项为空时默认为 false
+}
+type DeviceAuth5AccessReq {
+    Username string `json:"username,omitempty"` //用户名
+    Topic    string `json:"topic,omitempty"`    //主题
+    ClientID string `json:"clientID,omitempty"` //clientID
+    Action   string `json:"action,omitempty"`   //操作
+    Ip       string `json:"ip,omitempty"`       //访问的ip地址
+}
+type DeviceAuth5AccessResp {
+    Result      string `json:"result"`              //验证结果 "allow" | "deny" | "ignore"
+}

--- a/src/apisvr/internal/handler/routes.go
+++ b/src/apisvr/internal/handler/routes.go
@@ -9,6 +9,7 @@ import (
 	systemrole "github.com/i-Things/things/src/apisvr/internal/handler/system/role"
 	systemuser "github.com/i-Things/things/src/apisvr/internal/handler/system/user"
 	thingsdeviceauth "github.com/i-Things/things/src/apisvr/internal/handler/things/device/auth"
+	thingsdeviceauth5 "github.com/i-Things/things/src/apisvr/internal/handler/things/device/auth5"
 	thingsdevicegateway "github.com/i-Things/things/src/apisvr/internal/handler/things/device/gateway"
 	thingsdeviceinfo "github.com/i-Things/things/src/apisvr/internal/handler/things/device/info"
 	thingsdeviceinteract "github.com/i-Things/things/src/apisvr/internal/handler/things/device/interact"
@@ -172,6 +173,22 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 			},
 		},
 		rest.WithPrefix("/api/v1/things/device/auth"),
+	)
+
+	server.AddRoutes(
+		[]rest.Route{
+			{
+				Method:  http.MethodPost,
+				Path:    "/login",
+				Handler: thingsdeviceauth5.LoginHandler(serverCtx),
+			},
+			{
+				Method:  http.MethodPost,
+				Path:    "/access",
+				Handler: thingsdeviceauth5.AccessHandler(serverCtx),
+			},
+		},
+		rest.WithPrefix("/api/v1/things/device/auth5"),
 	)
 
 	server.AddRoutes(

--- a/src/apisvr/internal/handler/things/device/auth5/accesshandler.go
+++ b/src/apisvr/internal/handler/things/device/auth5/accesshandler.go
@@ -1,0 +1,25 @@
+package auth5
+
+import (
+	"github.com/i-Things/things/shared/result"
+	"github.com/i-Things/things/src/apisvr/internal/logic/things/device/auth5"
+	"net/http"
+
+	"github.com/i-Things/things/src/apisvr/internal/svc"
+	"github.com/i-Things/things/src/apisvr/internal/types"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func AccessHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.DeviceAuth5AccessReq
+		if err := httpx.Parse(r, &req); err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+			return
+		}
+
+		l := auth5.NewAccessLogic(r.Context(), svcCtx)
+		resp, err := l.Access(&req)
+		result.HttpWithoutWrap(w, r, resp, err)
+	}
+}

--- a/src/apisvr/internal/handler/things/device/auth5/loginhandler.go
+++ b/src/apisvr/internal/handler/things/device/auth5/loginhandler.go
@@ -1,0 +1,26 @@
+package auth5
+
+import (
+	"github.com/i-Things/things/shared/errors"
+	"github.com/i-Things/things/shared/result"
+	"github.com/i-Things/things/src/apisvr/internal/logic/things/device/auth5"
+	"net/http"
+
+	"github.com/i-Things/things/src/apisvr/internal/svc"
+	"github.com/i-Things/things/src/apisvr/internal/types"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func LoginHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.DeviceAuth5LoginReq
+		if err := httpx.Parse(r, &req); err != nil {
+			result.Http(w, r, nil, errors.Parameter.AddMsg(err.Error()))
+			return
+		}
+
+		l := auth5.NewLoginLogic(r.Context(), svcCtx)
+		resp, err := l.Login(&req)
+		result.HttpWithoutWrap(w, r, resp, err)
+	}
+}

--- a/src/apisvr/internal/logic/things/device/auth5/accesslogic.go
+++ b/src/apisvr/internal/logic/things/device/auth5/accesslogic.go
@@ -1,0 +1,53 @@
+package auth5
+
+import (
+	"context"
+	"github.com/i-Things/things/shared/devices"
+	"github.com/i-Things/things/shared/errors"
+	"github.com/i-Things/things/shared/utils"
+	"github.com/i-Things/things/src/dmsvr/pb/dm"
+
+	"github.com/i-Things/things/src/apisvr/internal/svc"
+	"github.com/i-Things/things/src/apisvr/internal/types"
+
+	"github.com/zeromicro/go-zero/core/logx"
+)
+
+type AccessLogic struct {
+	logx.Logger
+	ctx    context.Context
+	svcCtx *svc.ServiceContext
+}
+
+func NewAccessLogic(ctx context.Context, svcCtx *svc.ServiceContext) *AccessLogic {
+	return &AccessLogic{
+		Logger: logx.WithContext(ctx),
+		ctx:    ctx,
+		svcCtx: svcCtx,
+	}
+}
+
+func (l *AccessLogic) Access(req *types.DeviceAuth5AccessReq) (resp *types.DeviceAuth5AccessResp, err error) {
+	l.Infof("%s req=%v", utils.FuncName(), req)
+	action := req.Action
+	//如果是
+	switch req.Action {
+	case "subscribe":
+		action = devices.Sub
+	case "publish":
+		action = devices.Pub
+	}
+	_, err = l.svcCtx.DeviceA.AccessAuth(l.ctx, &dm.AccessAuthReq{
+		Username: req.Username,
+		Topic:    req.Topic,
+		ClientID: req.ClientID,
+		Access:   action,
+		Ip:       req.Ip,
+	})
+	if err != nil {
+		er := errors.Fmt(err)
+		l.Errorf("%s.rpc.AccessAuth req=%v err=%+v", utils.FuncName(), req, er)
+		return nil, er
+	}
+	return &types.DeviceAuth5AccessResp{Result: "allow"}, nil
+}

--- a/src/apisvr/internal/logic/things/device/auth5/loginlogic.go
+++ b/src/apisvr/internal/logic/things/device/auth5/loginlogic.go
@@ -1,0 +1,73 @@
+package auth5
+
+import (
+	"context"
+	"encoding/base64"
+	"github.com/i-Things/things/shared/errors"
+	"github.com/i-Things/things/shared/utils"
+	"github.com/i-Things/things/src/dmsvr/pb/dm"
+
+	"github.com/i-Things/things/src/apisvr/internal/svc"
+	"github.com/i-Things/things/src/apisvr/internal/types"
+
+	"github.com/zeromicro/go-zero/core/logx"
+)
+
+type LoginLogic struct {
+	logx.Logger
+	ctx    context.Context
+	svcCtx *svc.ServiceContext
+}
+
+func NewLoginLogic(ctx context.Context, svcCtx *svc.ServiceContext) *LoginLogic {
+	return &LoginLogic{
+		Logger: logx.WithContext(ctx),
+		ctx:    ctx,
+		svcCtx: svcCtx,
+	}
+}
+
+func (l *LoginLogic) Login(req *types.DeviceAuth5LoginReq) (resp *types.DeviceAuth5LoginResp, err error) {
+	l.Infof("%s req=%+v", utils.FuncName(), req)
+	var (
+		cert []byte
+	)
+
+	// superuser
+	_, err = l.svcCtx.DeviceA.RootCheck(l.ctx, &dm.RootCheckReq{
+		Username:    req.Username,
+		Password:    req.Password,
+		ClientID:    req.ClientID,
+		Ip:          req.Ip,
+		Certificate: cert,
+	})
+	if err == nil {
+		return &types.DeviceAuth5LoginResp{
+			Result:      "allow",
+			IsSuperuser: true,
+		}, nil
+	}
+	// device auth
+	if req.Certificate != "" {
+		cert, err = base64.StdEncoding.DecodeString(req.Certificate)
+		if err != nil {
+			return nil, errors.Parameter.AddDetail("certificate can base64 decode")
+		}
+
+	}
+	_, err = l.svcCtx.DeviceA.LoginAuth(l.ctx, &dm.LoginAuthReq{Username: req.Username, //用户名
+		Password:    req.Password, //密码
+		ClientID:    req.ClientID, //clientID
+		Ip:          req.Ip,       //访问的ip地址
+		Certificate: cert,         //客户端证书
+	})
+	if err != nil {
+		er := errors.Fmt(err)
+		l.Errorf("%s.rpc.ManageDevice req=%v err=%+v", utils.FuncName(), req, er)
+		return nil, er
+	}
+	return &types.DeviceAuth5LoginResp{
+		Result:      "allow",
+		IsSuperuser: false,
+	}, nil
+}

--- a/src/apisvr/internal/types/types.go
+++ b/src/apisvr/internal/types/types.go
@@ -274,6 +274,31 @@ type DeviceAuthRootCheckReq struct {
 	Certificate []byte `json:"certificate,optional,omitempty"` //客户端证书
 }
 
+type DeviceAuth5LoginReq struct {
+	Username    string `json:"username"`                       //用户名
+	Password    string `json:"password,optional"`              //密码
+	ClientID    string `json:"clientID"`                       //clientID
+	Ip          string `json:"ip"`                             //访问的ip地址
+	Certificate string `json:"certificate,optional,omitempty"` //客户端证书 base64后传过来
+}
+
+type DeviceAuth5LoginResp struct {
+	Result      string `json:"result"`                //验证结果 "allow" | "deny" | "ignore"
+	IsSuperuser bool   `json:"is_superuser,optional"` //是否为超级用户，可选 true | false，该项为空时默认为 false
+}
+
+type DeviceAuth5AccessReq struct {
+	Username string `json:"username,omitempty"` //用户名
+	Topic    string `json:"topic,omitempty"`    //主题
+	ClientID string `json:"clientID,omitempty"` //clientID
+	Action   string `json:"action,omitempty"`   //操作
+	Ip       string `json:"ip,omitempty"`       //访问的ip地址
+}
+
+type DeviceAuth5AccessResp struct {
+	Result string `json:"result"` //验证结果 "allow" | "deny" | "ignore"
+}
+
 type DeviceMsgHubLogIndexReq struct {
 	DeviceName string    `json:"deviceName,omitempty"`                //设备名
 	ProductID  string    `json:"productID,omitempty"`                 //产品id 获取产品id下的所有设备信息


### PR DESCRIPTION
## 背景
自EMQX 5.0开始，http认证应答改为如下格式：

```http
HTTP/1.1 200 OK
Headers: Content-Type: application/json
...
Body:
{
    "result": "allow", // 可选 "allow" | "deny" | "ignore"
    "is_superuser": true // 可选 true | false，该项为空时默认为 false
}
```

http授权应答改为如下格式：

```http
HTTP/1.1 200 OK
Headers: Content-Type: application/json
...
Body:
{
    "result": "allow", // 可选 "allow" | "deny" | "ignore"，默认 ignore
}
```

## 细节

1. 新增`device/auth5/login`和`device/auth5/access`接口
2. 增加`HttpWithoutWrap`方法，去除Http应答包装，原样返回

## 参考资料

> [EMQX 5 HTTP认证说明](https://www.emqx.io/docs/zh/v5.0/access-control/authn/http.html#%E8%AF%B7%E6%B1%82%E6%A0%BC%E5%BC%8F%E4%B8%8E%E8%BF%94%E5%9B%9E%E7%BB%93%E6%9E%9C)
> [EMQX 5 HTTP授权说明](https://www.emqx.io/docs/zh/v5.0/access-control/authz/http.html#%E8%AF%B7%E6%B1%82%E6%A0%BC%E5%BC%8F%E4%B8%8E%E8%BF%94%E5%9B%9E%E7%BB%93%E6%9E%9C)